### PR TITLE
fix: remove keyword 'stage' in vertex/fragment/compute shaders

### DIFF
--- a/src/shaders/basic.instanced.vert.wgsl
+++ b/src/shaders/basic.instanced.vert.wgsl
@@ -7,7 +7,7 @@ struct VertexOutput {
 
 };
 
-@stage(vertex)
+@vertex
 fn main(
     @builtin(instance_index) index : u32,
     @location(0) position : vec4<f32>,

--- a/src/shaders/basic.vert.wgsl
+++ b/src/shaders/basic.vert.wgsl
@@ -6,7 +6,7 @@ struct VertexOutput {
     @location(1) fragPosition: vec4<f32>
 };
 
-@stage(vertex)
+@vertex
 fn main(
     @location(0) position : vec4<f32>,
     @location(1) uv : vec2<f32>

--- a/src/shaders/color.frag.wgsl
+++ b/src/shaders/color.frag.wgsl
@@ -1,6 +1,6 @@
 @group(0) @binding(0) var<uniform> color : vec4<f32>;
 
-@stage(fragment)
+@fragment
 fn main() -> @location(0) vec4<f32> {
     return color;
 }

--- a/src/shaders/compute.transform.wgsl
+++ b/src/shaders/compute.transform.wgsl
@@ -3,7 +3,7 @@
 @group(0) @binding(2) var<storage, read_write> mvp : array<mat4x4<f32>>;
 @group(0) @binding(3) var<uniform> count : u32;
 
-@stage(compute) @workgroup_size(128)
+@compute @workgroup_size(128)
 fn main(@builtin(global_invocation_id) global_id : vec3<u32>) {
     // Guard against out-of-bounds work group sizes
     let index = global_id.x;

--- a/src/shaders/imageTexture.frag.wgsl
+++ b/src/shaders/imageTexture.frag.wgsl
@@ -1,7 +1,7 @@
 @group(1) @binding(0) var Sampler: sampler;
 @group(1) @binding(1) var Texture: texture_2d<f32>;
 
-@stage(fragment)
+@fragment
 fn main(@location(0) fragUV: vec2<f32>,
         @location(1) fragPosition: vec4<f32>) -> @location(0) vec4<f32> {
   return textureSample(Texture, Sampler, fragUV) * fragPosition;

--- a/src/shaders/lambert.frag.wgsl
+++ b/src/shaders/lambert.frag.wgsl
@@ -2,7 +2,7 @@
 @group(1) @binding(1) var<uniform> pointLight : array<vec4<f32>, 2>;
 @group(1) @binding(2) var<uniform> directionLight : array<vec4<f32>, 2>;
 
-@stage(fragment)
+@fragment
 fn main(
     @location(0) fragPosition : vec3<f32>,
     @location(1) fragNormal: vec3<f32>,

--- a/src/shaders/normal.vert.wgsl
+++ b/src/shaders/normal.vert.wgsl
@@ -10,7 +10,7 @@ struct VertexOutput {
     @location(3) fragColor: vec4<f32>
 };
 
-@stage(vertex)
+@vertex
 fn main(
     @builtin(instance_index) index : u32,
     @location(0) position : vec3<f32>,

--- a/src/shaders/position.frag.wgsl
+++ b/src/shaders/position.frag.wgsl
@@ -1,4 +1,4 @@
-@stage(fragment)
+@fragment
 fn main(
     @location(0) fragUV: vec2<f32>,
     @location(1) fragPosition: vec4<f32>

--- a/src/shaders/position.vert.wgsl
+++ b/src/shaders/position.vert.wgsl
@@ -1,4 +1,4 @@
-@stage(vertex)
+@vertex
 fn main(@location(0) position : vec3<f32>) -> @builtin(position) vec4<f32> {
     return vec4<f32>(position, 1.0);
 }

--- a/src/shaders/red.frag.wgsl
+++ b/src/shaders/red.frag.wgsl
@@ -1,4 +1,4 @@
-@stage(fragment)
+@fragment
 fn main() -> @location(0) vec4<f32> {
     return vec4<f32>(1.0, 0.0, 0.0, 1.0);
 }

--- a/src/shaders/shadow.frag.wgsl
+++ b/src/shaders/shadow.frag.wgsl
@@ -2,7 +2,7 @@
 @group(1) @binding(1) var shadowMap: texture_depth_2d;
 @group(1) @binding(2) var shadowSampler: sampler_comparison;
 
-@stage(fragment)
+@fragment
 fn main(
     @location(0) fragPosition : vec3<f32>,
     @location(1) fragNormal: vec3<f32>,

--- a/src/shaders/shadow.vertex.wgsl
+++ b/src/shaders/shadow.vertex.wgsl
@@ -12,7 +12,7 @@ struct VertexOutput {
     @location(4) fragColor: vec4<f32>
 };
 
-@stage(vertex)
+@vertex
 fn main(
     @builtin(instance_index) index : u32,
     @location(0) position : vec3<f32>,

--- a/src/shaders/shadowDepth.wgsl
+++ b/src/shaders/shadowDepth.wgsl
@@ -1,7 +1,7 @@
 @group(0) @binding(0) var<storage> modelViews : array<mat4x4<f32>>;
 @group(0) @binding(1) var<uniform> lightProjection : mat4x4<f32>;
 
-@stage(vertex)
+@vertex
 fn main(
     @builtin(instance_index) index : u32,
     @location(0) position : vec3<f32>,

--- a/src/shaders/triangle.vert.wgsl
+++ b/src/shaders/triangle.vert.wgsl
@@ -1,4 +1,4 @@
-@stage(vertex)
+@vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
     var pos = array<vec2<f32>, 3>(
 	    vec2<f32>(0.0, 0.5),

--- a/src/shaders/videoTexture.frag.wgsl
+++ b/src/shaders/videoTexture.frag.wgsl
@@ -1,7 +1,7 @@
 @group(1) @binding(0) var Sampler: sampler;
 @group(1) @binding(1) var Texture: texture_external;
 
-@stage(fragment)
+@fragment
 fn main(@location(0) fragUV: vec2<f32>,
         @location(1) fragPosition: vec4<f32>) -> @location(0) vec4<f32> {
   return textureSampleLevel(Texture, Sampler, fragUV) * fragPosition;


### PR DESCRIPTION
This PR changes '@stage(xxx)' to '@xxx' in vertex/fragment/compute shaders. 
The latest chrome canary prints warning of the deprecated keyword 'stage', FYI. 